### PR TITLE
fix: Adjust Markdown Headings for Versions in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.2.2](https://github.com/ui5-community/create-wdi5/compare/v0.2.1...v0.2.2) (2022-07-08)
+## [0.2.2](https://github.com/ui5-community/create-wdi5/compare/v0.2.1...v0.2.2) (2022-07-08)
 
 
 ### Bug Fixes
 
 * add missing types ([3e944a0](https://github.com/ui5-community/create-wdi5/commit/3e944a0b7f272777b34c8f4c777003d6fd385a02))
 
-### [0.2.1](https://github.com/ui5-community/create-wdi5/compare/v0.2.0...v0.2.1) (2022-07-04)
+## [0.2.1](https://github.com/ui5-community/create-wdi5/compare/v0.2.0...v0.2.1) (2022-07-04)
 
 ## [0.2.0](https://github.com/ui5-community/create-wdi5/compare/v0.1.1...v0.2.0) (2022-07-02)
 
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file. See [standa
 * --debug and --headless ([da13699](https://github.com/ui5-community/create-wdi5/commit/da13699aee7a7029fd1af646a2b70df2278f0d6c))
 * support wdio/wdi5 in typescript ([c363ab0](https://github.com/ui5-community/create-wdi5/commit/c363ab0619e9826ce6a43a3ee9d62ac9afd0aa08))
 
-### [0.1.1](https://github.com/ui5-community/create-wdi5/compare/v0.1.0...v0.1.1) (2022-06-19)
+## [0.1.1](https://github.com/ui5-community/create-wdi5/compare/v0.1.0...v0.1.1) (2022-06-19)
 
 
 ### Bug Fixes


### PR DESCRIPTION
same as in https://github.com/ui5-community/wdi5/pull/307