### PR TITLE
Feat/add placeholder and v7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The `wdi5` config is already prepared for
 
 You can pass the following optional flags to modify the quickstart of `wdi5`:
 
-- `--configPath <path to config>` custom path where your config file (`wdio.conf.js`) should be created
+`--configPath <path to config>` custom path where your config file (`wdio.conf.(j|t)s`) should be created
 - `--specs <path to specs>` custom path where your specs files are located (**only available in js-projects**)
 - `--baseUrl <application url>` custom url to your application (**only available in js-projects**)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The `wdi5` config is already prepared for
 
 ## Supported Options
 
-You can pass the following flags to modify the quickstart of wdi5:
+You can pass the following optional flags to modify the quickstart of `wdi5`:
 
 - `--configPath <path to config>` custom path where your config file (`wdio.conf.js`) should be created
 - `--specs <path to specs>` custom path where your specs files are located (**only available in js-projects**)

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The `wdi5` config is already prepared for
 
 You can pass the following flags to modify the quickstart of wdi5:
 
-- `--configPath ./wdi5` custom path where your config file (`wdio.conf.js`) should be created
-- `--specs ./wdi5/specs/**/*.test.js` custom path where your specs files are located (**only available in js-projects**)
-- `--baseUrl https://your.ui5.application.com` custom url to your application (**only available in js-projects**)
+- `--configPath <path to config>` custom path where your config file (`wdio.conf.js`) should be created
+- `--specs <path to specs>` custom path where your specs files are located (**only available in js-projects**)
+- `--baseUrl <application url>` custom url to your application (**only available in js-projects**)
 
 ## next
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ $> cd your/ui5/app
 $> npm init wdi5@latest
 # for TypeScript projects:
 $> npm init wdi5@latest -- --ts
+
 ```
 
 Note that specifically for the TypeScript projects, this quickstart command is suited as a complimentary tool [to `yo easy-ui5 ts-app`!](https://github.com/ui5-community/generator-ui5-ts-app)
@@ -37,6 +38,14 @@ The `wdi5` config is already prepared for
 
 - `--headless`: runs Chrome in headless mode (`npm run wdi5 -- --headless`)
 - `--debug`: extends test timeouts and auto-opens Chrome's developer tools pane (`npm run wdi5 -- --debug`)
+
+## Supported Options
+
+You can pass the following flags to modify the quickstart of wdi5:
+
+- `--configPath ./wdi5` custom path where your config file (`wdio.conf.js`) should be created
+- `--specs ./wdi5/specs/**/*.test.js` custom path where your specs files are located (**only available in js-projects**)
+- `--baseUrl https://your.ui5.application.com` custom url to your application (**only available in js-projects**)
 
 ## next
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The `wdi5` config is already prepared for
 
 ## Supported Options
 
-You can pass the following optional flags to modify the quickstart of `wdi5`:
+You can pass the following _optional_ flags to modify the quickstart of `wdi5`:
 
-`--configPath <path to config>` custom path where your config file (`wdio.conf.(j|t)s`) should be created
-- `--specs <path to specs>` custom path where your specs files are located (**only available in js-projects**)
-- `--baseUrl <application url>` custom url to your application (**only available in js-projects**)
+- `--configPath <path to config>` custom path where your config file (`wdio.conf.(j|t)s`) should be created
+- `--specs <path to specs>` custom path where your specs files are located
+- `--baseUrl <application url>` custom url to your application
 
 ## next
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ async function initJS() {
     console.log(greenBright("👍 done!"))
 
     console.log(gray('≡> adding wdi5 start command ("wdi5") to package.json...'))
-    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath ? configPath : process.cwd()}wdio.conf.js"`, {
+    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath}wdio.conf.js"`, {
         stdio: "inherit"
     })
     console.log(greenBright("👍 done!"))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { execSync } from "child_process"
 import { gray, greenBright, yellowBright } from "colorette"
 import { copyFile } from "fs/promises"
+import path from "path"
+import fs from "fs/promises"
 
 const DEV_DEPS = [
     "@wdio/cli@7",
@@ -13,16 +15,30 @@ const DEV_DEPS = [
 ]
 
 const DEV_DEPS_TS = [...DEV_DEPS, "ts-node", "typescript"]
+let root: string | undefined
 
 export async function run() {
     process.env.DEBUG && console.info("//> process.argv:")
     process.env.DEBUG && console.info(process.argv)
+
+    if (process.argv.findIndex((arg) => arg.includes("configPath"))) {
+        const index = process.argv.findIndex((arg) => arg.includes("configPath")) + 1
+        root = path.resolve(process.cwd(), process.argv[index])
+        const rootDirExists = await fs.access(root).then(
+            () => true,
+            () => false
+        )
+        if (!rootDirExists) {
+            await fs.mkdir(root, { recursive: true })
+        }
+    }
+
     process.argv.find((arg) => arg.includes("ts")) ? await initTS() : await initJS()
 }
 
 async function initJS() {
     console.log(gray("≡> copying wdio.conf.js into place..."))
-    await copyFile(`${__dirname}/../templates/wdio.conf.js`, `${process.cwd()}/wdio.conf.js`)
+    await copyFile(`${__dirname}/../templates/wdio.conf.js`, `${root ? root : process.cwd()}/wdio.conf.js`)
     console.log(greenBright("👍 done!"))
 
     console.log(gray("≡> installing wdio + wdi5 and adding them as dev dependencies..."))
@@ -36,9 +52,9 @@ async function initJS() {
 
 async function initTS() {
     console.log(gray('≡> copying tsconfig.json into "./test/"...'))
-    await copyFile(`${__dirname}/../templates/test/tsconfig.json`, `${process.cwd()}/test/tsconfig.json`)
+    await copyFile(`${__dirname}/../templates/test/tsconfig.json`, `${root ? root : process.cwd()}/test/tsconfig.json`)
     console.log(gray('≡> copying wdio.conf.ts into "./"...'))
-    await copyFile(`${__dirname}/../templates/wdio.conf.ts`, `${process.cwd()}/wdio.conf.ts`)
+    await copyFile(`${__dirname}/../templates/wdio.conf.ts`, `${root ? root : process.cwd()}/wdio.conf.ts`)
     console.log(greenBright("👍 done!"))
 
     console.log(gray("≡> installing wdio + wdi5 and adding them as dev dependencies..."))
@@ -46,7 +62,7 @@ async function initTS() {
     console.log(greenBright("👍 done!"))
 
     console.log(
-        yellowBright(`\n≡> if your're using eslint, please add the "test"'s tsconfig.json to its' project setting: 
+        yellowBright(`\n≡> if your're using eslint, please add the "test"'s tsconfig.json to its' project setting:
     "project": ["./tsconfig.json", "./test/tsconfig.json"]\n`)
     )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { execSync } from "child_process"
 import { gray, greenBright, yellowBright } from "colorette"
-import { copyFile } from "fs/promises"
 import path from "path"
 import fs from "fs/promises"
 
@@ -67,7 +66,7 @@ export async function run() {
 async function initJS() {
     const wdioConf = path.resolve(fullConfigPath, "wdio.conf.js")
     console.log(gray(`≡> copying wdio.conf.js into "${configPath}"`))
-    await copyFile(`${__dirname}/../templates/wdio.conf.js`, wdioConf)
+    await fs.copyFile(`${__dirname}/../templates/wdio.conf.js`, wdioConf)
     await _replacePlaceholder(wdioConf)
     console.log(greenBright("👍 done!"))
 
@@ -84,11 +83,11 @@ async function initJS() {
 
 async function initTS() {
     console.log(gray(`≡> copying tsconfig.json into "${relativeTestDir}"...`))
-    await copyFile(`${__dirname}/../templates/test/tsconfig.json`, path.resolve(absoluteTestDir, "tsconfig.json"))
+    await fs.copyFile(`${__dirname}/../templates/test/tsconfig.json`, path.resolve(absoluteTestDir, "tsconfig.json"))
 
     const wdioConf = path.resolve(fullConfigPath, "wdio.conf.ts")
     console.log(gray(`≡> copying wdio.conf.ts into "${configPath}"`))
-    await copyFile(`${__dirname}/../templates/wdio.conf.ts`, wdioConf)
+    await fs.copyFile(`${__dirname}/../templates/wdio.conf.ts`, wdioConf)
     await _replacePlaceholder(wdioConf)
     console.log(greenBright("👍 done!"))
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,37 +16,59 @@ const DEV_DEPS = [
 
 const DEV_DEPS_TS = [...DEV_DEPS, "ts-node", "typescript"]
 let configPath = "./"
-let fullConfigPath: string | undefined
+let fullConfigPath: string
 let BASE_URL = "http://localhost:8080/index.html"
-let SPECS = "./webapp/test/**/*.test.js"
+let SPECS: string
+let relativeTestDir: string
+let absoluteTestDir: string
+let ts = false // whether we're working in TS land
 
 export async function run() {
     process.env.DEBUG && console.info("//> process.argv:")
     process.env.DEBUG && console.info(process.argv)
 
+    ts = process.argv.find((arg) => arg.includes("ts")) ? true : false
+
     if (process.argv.find((arg) => arg.includes("configPath"))) {
         const index = process.argv.findIndex((arg) => arg.includes("configPath")) + 1
         configPath = process.argv[index]
-        fullConfigPath = path.resolve(process.cwd(), configPath)
-        const rootDirExists = await fs.access(fullConfigPath).then(
-            () => true,
-            () => false
-        )
-        if (!rootDirExists) {
-            await fs.mkdir(fullConfigPath, { recursive: true })
-        }
+        configPath = configPath.endsWith(path.sep) ? configPath : configPath + path.sep
     }
 
-    process.argv.find((arg) => arg.includes("ts")) ? await initTS() : await initJS()
+    fullConfigPath = path.resolve(process.cwd(), configPath)
+    const rootDirExists = await fs.access(fullConfigPath).then(
+        () => true,
+        () => false
+    )
+    if (!rootDirExists) {
+        process.env.DEBUG && console.info(`//> created ${fullConfigPath}`)
+        await fs.mkdir(fullConfigPath, { recursive: true })
+    }
+
+    relativeTestDir = ts ? "./test" : "./webapp/test"
+    absoluteTestDir = path.resolve(process.cwd(), relativeTestDir)
+    const testDirExists = await fs.access(absoluteTestDir).then(
+        () => true,
+        () => false
+    )
+    if (!testDirExists) {
+        await fs.mkdir(absoluteTestDir, { recursive: true })
+    }
+
+    if (ts) {
+        SPECS = "./test/**/*.test.ts"
+        await initTS()
+    } else {
+        SPECS = "./webapp/test/**/*.test.js"
+        await initJS()
+    }
 }
 
 async function initJS() {
+    const wdioConf = path.resolve(fullConfigPath, "wdio.conf.js")
     console.log(gray(`≡> copying wdio.conf.js into "${configPath}"`))
-    await copyFile(
-        `${__dirname}/../templates/wdio.conf.js`,
-        `${fullConfigPath ? fullConfigPath : process.cwd()}/wdio.conf.js`
-    )
-    await _replacePlaceholder()
+    await copyFile(`${__dirname}/../templates/wdio.conf.js`, wdioConf)
+    await _replacePlaceholder(wdioConf)
     console.log(greenBright("👍 done!"))
 
     console.log(gray("≡> installing wdio + wdi5 and adding them as dev dependencies..."))
@@ -61,16 +83,13 @@ async function initJS() {
 }
 
 async function initTS() {
-    console.log(gray(`≡> copying tsconfig.json into ${configPath ? configPath : "./test/"}...`))
-    await copyFile(
-        `${__dirname}/../templates/test/tsconfig.json`,
-        `${fullConfigPath ? fullConfigPath : process.cwd()}/test/tsconfig.json`
-    )
+    console.log(gray(`≡> copying tsconfig.json into "${relativeTestDir}"...`))
+    await copyFile(`${__dirname}/../templates/test/tsconfig.json`, path.resolve(absoluteTestDir, "tsconfig.json"))
+
+    const wdioConf = path.resolve(fullConfigPath, "wdio.conf.ts")
     console.log(gray(`≡> copying wdio.conf.ts into "${configPath}"`))
-    await copyFile(
-        `${__dirname}/../templates/wdio.conf.ts`,
-        `${fullConfigPath ? fullConfigPath : process.cwd()}/wdio.conf.ts`
-    )
+    await copyFile(`${__dirname}/../templates/wdio.conf.ts`, wdioConf)
+    await _replacePlaceholder(wdioConf)
     console.log(greenBright("👍 done!"))
 
     console.log(gray("≡> installing wdio + wdi5 and adding them as dev dependencies..."))
@@ -79,7 +98,7 @@ async function initTS() {
 
     console.log(
         yellowBright(`\n≡> if your're using eslint, please add the "test"'s tsconfig.json to its' project setting:
-    "project": ["./tsconfig.json", "./test/tsconfig.json"]\n`)
+    "project": ["./tsconfig.json", "${relativeTestDir}/tsconfig.json"]\n`)
     )
 
     console.log(gray("≡> adding wdi5 start command to package.json..."))
@@ -89,7 +108,7 @@ async function initTS() {
     console.log(greenBright("👍 done!"))
 }
 
-async function _replacePlaceholder() {
+async function _replacePlaceholder(wdioConf: string) {
     if (process.argv.find((arg) => arg.includes("specs"))) {
         const index = process.argv.findIndex((arg) => arg.includes("specs")) + 1
         SPECS = process.argv[index]
@@ -100,9 +119,9 @@ async function _replacePlaceholder() {
         BASE_URL = process.argv[index]
     }
 
-    const data = await fs.readFile(`${fullConfigPath ? fullConfigPath : process.cwd()}/wdio.conf.js`)
+    const data = await fs.readFile(wdioConf)
     let fileString = data.toString()
     fileString = fileString.replace(/%specs%/g, SPECS)
     fileString = fileString.replace(/%baseUrl%/g, BASE_URL)
-    await fs.writeFile(`${fullConfigPath ? fullConfigPath : process.cwd()}/wdio.conf.js`, fileString)
+    await fs.writeFile(wdioConf, fileString)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ async function initJS() {
     console.log(greenBright("👍 done!"))
 
     console.log(gray('≡> adding wdi5 start command ("wdi5") to package.json...'))
-    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath ? configPath : process.cwd()}/wdio.conf.js"`, {
+    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath ? configPath : process.cwd()}wdio.conf.js"`, {
         stdio: "inherit"
     })
     console.log(greenBright("👍 done!"))
@@ -102,7 +102,7 @@ async function initTS() {
     )
 
     console.log(gray("≡> adding wdi5 start command to package.json..."))
-    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath ? configPath : process.cwd()}/wdio.conf.ts"`, {
+    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath ? configPath : process.cwd()}wdio.conf.ts"`, {
         stdio: "inherit"
     })
     console.log(greenBright("👍 done!"))

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ async function initJS() {
 }
 
 async function initTS() {
-    console.log(gray('≡> copying tsconfig.json into "./test/"...'))
+    console.log(gray(`≡> copying tsconfig.json into ${configPath ? configPath : "./test/"}...`))
     await copyFile(
         `${__dirname}/../templates/test/tsconfig.json`,
         `${fullConfigPath ? fullConfigPath : process.cwd()}/test/tsconfig.json`

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ async function initTS() {
     )
 
     console.log(gray("≡> adding wdi5 start command to package.json..."))
-    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath ? configPath : process.cwd()}wdio.conf.ts"`, {
+    execSync(`npm pkg set scripts.wdi5="wdio run ${configPath}wdio.conf.ts"`, {
         stdio: "inherit"
     })
     console.log(greenBright("👍 done!"))

--- a/templates/wdio.conf.js
+++ b/templates/wdio.conf.js
@@ -1,11 +1,15 @@
 exports.config = {
-    wdi5: {
-        screenshotPath: "webapp/test/__screenshots__",
-        screenshotsDisabled: false, // [optional] {boolean}, default: false; if set to true, screenshots won't be taken and not written to file system
-        logLevel: "error", // [optional] error | verbose | silent, default: "error"
-        skipInjectUI5OnStart: false, // [optional] {boolean}, default: false; true when UI5 is not on the start page, you need to later call <wdioUI5service>.injectUI5() manually
-        waitForUI5Timeout: 15000 // [optional] {number}, default: 15000; maximum waiting time in milliseconds while checking for UI5 availability
-    },
+    // ====================
+    // wdi5 Configuration
+    // ====================
+    //
+    // wdi5: {
+    //     screenshotPath: require("path").join("some", "dir", "for", "screenshots"),c // [optional] {string}, default: ""
+    //     screenshotsDisabled: false, // [optional] {boolean}, default: false; if set to true, screenshots won't be taken and not written to file system
+    //     logLevel: "error", // [optional] error | verbose | silent, default: "error"
+    //     skipInjectUI5OnStart: false, // [optional] {boolean}, default: false; true when UI5 is not on the start page, you need to later call <wdioUI5service>.injectUI5() manually
+    //     waitForUI5Timeout: 15000 // [optional] {number}, default: 15000; maximum waiting time in milliseconds while checking for UI5 availability
+    // },
     //
     // ====================
     // Runner Configuration

--- a/templates/wdio.conf.js
+++ b/templates/wdio.conf.js
@@ -31,7 +31,7 @@ exports.config = {
     // then the current working directory is where your `package.json` resides, so `wdio`
     // will be called from there.
     //
-    specs: ["./webapp/test/**/*.test.js"],
+    specs: ["%specs%"],
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'
@@ -112,7 +112,7 @@ exports.config = {
     // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
     // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
     // gets prepended directly.
-    baseUrl: "http://localhost:8080/index.html",
+    baseUrl: "%baseUrl%",
     //
     // Default timeout for all waitFor* commands.
     waitforTimeout: 10000,

--- a/templates/wdio.conf.ts
+++ b/templates/wdio.conf.ts
@@ -1,13 +1,17 @@
 import { wdi5Config } from "wdio-ui5-service/dist/types/wdi5.types"
 
 export const config: wdi5Config = {
-    wdi5: {
-        screenshotPath: "__screenshots__",
-        screenshotsDisabled: false, // [optional] {boolean}, default: false; if set to true, screenshots won't be taken and not written to file system
-        logLevel: "error", // [optional] error | verbose | silent, default: "error"
-        skipInjectUI5OnStart: false, // [optional] {boolean}, default: false; true when UI5 is not on the start page, you need to later call <wdioUI5service>.injectUI5() manually
-        waitForUI5Timeout: 15000 // [optional] {number}, default: 15000; maximum waiting time in milliseconds while checking for UI5 availability
-    },
+    // ====================
+    // wdi5 Configuration
+    // ====================
+    //
+    // wdi5: {
+    //     screenshotPath: require("path").join("some", "dir", "for", "screenshots"),c // [optional] {string}, default: ""
+    //     screenshotsDisabled: false, // [optional] {boolean}, default: false; if set to true, screenshots won't be taken and not written to file system
+    //     logLevel: "error", // [optional] error | verbose | silent, default: "error"
+    //     skipInjectUI5OnStart: false, // [optional] {boolean}, default: false; true when UI5 is not on the start page, you need to later call <wdioUI5service>.injectUI5() manually
+    //     waitForUI5Timeout: 15000 // [optional] {number}, default: 15000; maximum waiting time in milliseconds while checking for UI5 availability
+    // },
     //
     // ====================
     // Runner Configuration

--- a/templates/wdio.conf.ts
+++ b/templates/wdio.conf.ts
@@ -60,7 +60,7 @@ export const config: wdi5Config = {
     // then the current working directory is where your `package.json` resides, so `wdio`
     // will be called from there.
     //
-    specs: ["./test/**/*.test.ts"],
+    specs: ["%specs%"],
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'
@@ -140,7 +140,7 @@ export const config: wdi5Config = {
     // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
     // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
     // gets prepended directly.
-    baseUrl: "http://localhost:8080/index.html",
+    baseUrl: "%baseUrl%",
     //
     // Default timeout for all waitFor* commands.
     waitforTimeout: 10000,


### PR DESCRIPTION
- Use `wdio-chromedriver-service` v7 specifically to have a working quick install again
- Comment out the wdi5 configuration as it is now fully optional
- Allow a custom config path
- Allow custom `baseUrl` and `specs` (currently only for js-projects)