### PR TITLE
replace deprecated headless method

### DIFF
--- a/templates/wdio.conf.js
+++ b/templates/wdio.conf.js
@@ -70,7 +70,7 @@ exports.config = {
             "goog:chromeOptions": {
                 args:
                     process.argv.indexOf("--headless") > -1
-                        ? ["--headless"]
+                        ? ["--headless=new"]
                         : process.argv.indexOf("--debug") > -1
                         ? ["window-size=1440,800", "--auto-open-devtools-for-tabs"]
                         : ["window-size=1440,800"]

--- a/templates/wdio.conf.ts
+++ b/templates/wdio.conf.ts
@@ -98,7 +98,7 @@ export const config: wdi5Config = {
             "goog:chromeOptions": {
                 args:
                     process.argv.indexOf("--headless") > -1
-                        ? ["--headless"]
+                        ? ["--headless=new"]
                         : process.argv.indexOf("--debug") > -1
                           ? ["window-size=1440,800", "--auto-open-devtools-for-tabs"]
                           : ["window-size=1440,800"]


### PR DESCRIPTION
This Merge-Request replaces the deprecated "--headless" start argument for chrome with the new version "--headless=new". Please find further information here: https://www.selenium.dev/blog/2023/headless-is-going-away/

The Change fixes a bug where the browser wasn't able to run headless in incognito mode. For reference, please have a look into this thread: https://groups.google.com/g/ptgram24/c/zPQmJ_mRfzo